### PR TITLE
Fix syntax errors in switch cases for range checks

### DIFF
--- a/NNTP/Client.php
+++ b/NNTP/Client.php
@@ -1053,8 +1053,8 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
     	switch (true) {
 
     	    // Expect one article
-    	    case is_null($range);
-    	    case is_int($range);
+    	    case is_null($range):
+    	    case is_int($range):
             case is_string($range) && ctype_digit($range):
     	    case is_string($range) && substr($range, 0, 1) == '<' && substr($range, -1, 1) == '>':
     	        if (count($overview) === 0) {
@@ -1157,8 +1157,8 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
     	switch (true) {
 
     	    // Expect one article
-    	    case is_null($range);
-    	    case is_int($range);
+    	    case is_null($range):
+    	    case is_int($range):
             case is_string($range) && ctype_digit($range):
     	    case is_string($range) && substr($range, 0, 1) == '<' && substr($range, -1, 1) == '>':
 
@@ -1292,8 +1292,8 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
     	switch (true) {
 
     	    // Expect one article
-    	    case is_null($range);
-    	    case is_int($range);
+    	    case is_null($range):
+    	    case is_int($range):
     	    case is_string($range) && ctype_digit($range):
     	    case is_string($range) && substr($range, 0, 1) == '<' && substr($range, -1, 1) == '>':
     	        if (count($references) === 0) {


### PR DESCRIPTION
Fix PHP 8.5 deprecation errors:

` PHP Deprecated:  Case statements followed by a semicolon (;) are deprecated, use a colon (:)`