### PR TITLE
Optimize NNTP hot paths, fix command-length guard, and add XOVER-only integration benchmark

### DIFF
--- a/NNTP/Client.php
+++ b/NNTP/Client.php
@@ -997,8 +997,8 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
     	    return $overview;
     	}
 
-    	// Use field names from overview format as keys?
-    	if ($_names) {
+	    // Use field names from overview format as keys?
+	    if ($_names) {
 
     	    // Already cached?
     	    if (is_null($this->_overviewFormatCache)) {
@@ -1019,31 +1019,30 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
     	        $format = $this->_overviewFormatCache;
     	    }
 
-    	    // Loop through all articles
+	    	// Loop through all articles
+            $fieldNames = array_keys($format);
+            $fieldFlags = array_values($format);
+            $fieldCount = count($fieldNames);
+
             foreach ($overview as $key => $article) {
+                $mappedArticle = array();
 
-    	        // Copy $format
-    	        $f = $format;
+                for ($i = 0; $i < $fieldCount; $i++) {
+                    $value = $article[$i] ?? '';
 
-    	        // Field counter
-    	        $i = 0;
-		
-		// Loop through forld names in format
-    	        foreach ($f as $tag => $full) {
+                    // If prefixed by field name, remove it
+                    if ($fieldFlags[$i] === true) {
+                        $pos = strpos($value, ':');
+                        $value = ltrim(substr($value, ($pos === false ? 0 : $pos + 1)), " \t");
+                    }
 
-    	    	    //
-    	            $f[$tag] = $article[$i++];
+                    $mappedArticle[$fieldNames[$i]] = $value;
+                }
 
-    	            // If prefixed by field name, remove it
-    	            if ($full === true) {
-	                $f[$tag] = ltrim( substr($f[$tag], strpos($f[$tag], ':') + 1), " \t");
-    	            }
-    	        }
-
-    	        // Replace article 
-	        $overview[$key] = $f;
-    	    }
-    	}
+                // Replace article
+                $overview[$key] = $mappedArticle;
+            }
+	    }
 
     	//
     	switch (true) {

--- a/NNTP/Client.php
+++ b/NNTP/Client.php
@@ -152,7 +152,7 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
     public function connect(?string $host = null, mixed $encryption = null, ?int $port = null, ?int $timeout = null): mixed
     {
     	// v1.0.x API
-    	if (is_int($encryption)) {
+    	if (\is_int($encryption)) {
 	    trigger_error('You are using deprecated API v1.0 in Net_NNTP_Client: connect() !', E_USER_NOTICE);
     	    $port = $encryption;
 	    $encryption = null;
@@ -435,7 +435,7 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
     public function getArticle(mixed $article = null, bool $implode = false): mixed
     {
     	// v1.1.x API
-    	if (is_string($implode)) {
+    	if (\is_string($implode)) {
     	    trigger_error('You are using deprecated API v1.1 in Net_NNTP_Client: getHeader() !', E_USER_NOTICE);
 		     
     	    $class = $implode;
@@ -494,7 +494,7 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
     public function getHeader(mixed $article = null, bool $implode = false): mixed
     {
     	// v1.1.x API
-    	if (is_string($implode)) {
+    	if (\is_string($implode)) {
     	    trigger_error('You are using deprecated API v1.1 in Net_NNTP_Client: getHeader() !', E_USER_NOTICE);
 		     
     	    $class = $implode;
@@ -553,7 +553,7 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
     public function getBody(mixed $article = null, bool $implode = false)
     {
     	// v1.1.x API
-    	if (is_string($implode)) {
+    	if (\is_string($implode)) {
     	    trigger_error('You are using deprecated API v1.1 in Net_NNTP_Client: getHeader() !', E_USER_NOTICE);
 		     
     	    $class = $implode;
@@ -605,23 +605,23 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
     public function post(mixed $article): mixed
     {
     	// API v1.0
-    	if (func_num_args() >= 4) {
+    	if (\func_num_args() >= 4) {
 
     	    // 
     	    trigger_error('You are using deprecated API v1.0 in Net_NNTP_Client: post() !', E_USER_NOTICE);
 
     	    //
-    	    $groups = func_get_arg(0);
-    	    $subject = func_get_arg(1);
-    	    $body = func_get_arg(2);
-    	    $from = func_get_arg(3);
-    	    $additional = func_get_arg(4);
+    	    $groups = \func_get_arg(0);
+    	    $subject = \func_get_arg(1);
+    	    $body = \func_get_arg(2);
+    	    $from = \func_get_arg(3);
+    	    $additional = \func_get_arg(4);
 
     	    return $this->mail($groups, $subject, $body, "From: $from\r\n" . $additional);
     	}
 
     	// Only accept $article if array or string
-    	if (!is_array($article) && !is_string($article)) {
+    	if (!\is_array($article) && !\is_string($article)) {
     	    return $this->throwError('Ups', null, 0);
     	}
 
@@ -633,7 +633,7 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
 
     	// Get article data from callback function
     	if (is_callable($article)) {
-    	    $article = call_user_func($article);
+    	    $article = \call_user_func($article);
     	}
 
     	// Actually send the article
@@ -754,9 +754,9 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
     public function getNewGroups(mixed $time, ?string $distributions = null): mixed
     {
     	switch (true) {
-    	    case is_integer($time):
-    	    	break;
-    	    case is_string($time):
+case \is_integer($time):
+	    	break;
+    	    case \is_string($time):
     	    	$time = strtotime($time);
     	    	if ($time === false) {
     	    	    return $this->throwError('$time could not be converted into a timestamp!', null, 0);
@@ -796,9 +796,9 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
     public function getNewArticles(mixed $time, string $groups = '*', ?string $distribution = null)
     {
     	switch (true) {
-    	    case is_integer($time):
-    	    	break;
-    	    case is_string($time):
+case \is_integer($time):
+	    	break;
+    	    case \is_string($time):
     	    	$time = strtotime($time);
 				if ($time === false) {
 
@@ -852,7 +852,7 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
     	if ($backup === true) {
 
     	    // 
-    	    if (!is_null($wildmat)) {
+    	    if (!\is_null($wildmat)) {
     	    	return $this->throwError("The server does not support the 'LIST ACTIVE' command, and the 'LIST' command does not support the wildmat parameter!", null, null);
     	    }
 	    
@@ -898,7 +898,7 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
      */
     public function getDescriptions(mixed $wildmat = null): mixed
     {
-    	if (is_array($wildmat)) {
+    	if (\is_array($wildmat)) {
 	    $wildmat = implode(',', $wildmat);
     	}
 
@@ -962,10 +962,10 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
     	// API v1.0
     	switch (true) {
 	    // API v1.3
-	    case func_num_args() != 2:
-	    case is_bool(func_get_arg(1)):
-	    case !is_int(func_get_arg(1)) || (is_string(func_get_arg(1)) && ctype_digit(func_get_arg(1))):
-	    case !is_int(func_get_arg(0)) || (is_string(func_get_arg(0)) && ctype_digit(func_get_arg(0))):
+	    case \func_num_args() != 2:
+	    case \is_bool(\func_get_arg(1)):
+	    case !\is_int(\func_get_arg(1)) || (\is_string(\func_get_arg(1)) && ctype_digit(\func_get_arg(1))):
+	    case !\is_int(\func_get_arg(0)) || (\is_string(\func_get_arg(0)) && ctype_digit(\func_get_arg(0))):
 		break;
 
 	    default:
@@ -973,7 +973,7 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
     	        trigger_error('You are using deprecated API v1.0 in Net_NNTP_Client: getOverview() !', E_USER_NOTICE);
 
     	        // Fetch overview via API v1.3
-    	        $overview = $this->getOverview(func_get_arg(0) . '-' . func_get_arg(1), true, false);
+    	        $overview = $this->getOverview(\func_get_arg(0) . '-' . \func_get_arg(1), true, false);
     	        if (Net_NNTP_Error::isError($overview)) {
     	            return $overview;
     	        }
@@ -1001,7 +1001,7 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
 	    if ($_names) {
 
     	    // Already cached?
-    	    if (is_null($this->_overviewFormatCache)) {
+    	    if (\is_null($this->_overviewFormatCache)) {
     	    	// Fetch overview format
     	        $format = $this->getOverviewFormat($_forceNames, true);
     	        if (Net_NNTP_Error::isError($format)){
@@ -1022,7 +1022,7 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
 	    	// Loop through all articles
             $fieldNames = array_keys($format);
             $fieldFlags = array_values($format);
-            $fieldCount = count($fieldNames);
+            $fieldCount = \count($fieldNames);
 
             foreach ($overview as $key => $article) {
                 $mappedArticle = array();
@@ -1048,11 +1048,11 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
     	switch (true) {
 
     	    // Expect one article
-    	    case is_null($range):
-    	    case is_int($range):
-            case is_string($range) && ctype_digit($range):
-    	    case is_string($range) && substr($range, 0, 1) == '<' && substr($range, -1, 1) == '>':
-    	        if (count($overview) === 0) {
+    	    case \is_null($range):
+    	    case \is_int($range):
+            case \is_string($range) && ctype_digit($range):
+    	    case \is_string($range) && substr($range, 0, 1) == '<' && substr($range, -1, 1) == '>':
+    	        if (\count($overview) === 0) {
     	    	    return false;
     	    	}
 		    
@@ -1152,12 +1152,12 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
     	switch (true) {
 
     	    // Expect one article
-    	    case is_null($range):
-    	    case is_int($range):
-            case is_string($range) && ctype_digit($range):
-    	    case is_string($range) && substr($range, 0, 1) == '<' && substr($range, -1, 1) == '>':
+    	    case \is_null($range):
+    	    case \is_int($range):
+            case \is_string($range) && ctype_digit($range):
+    	    case \is_string($range) && substr($range, 0, 1) == '<' && substr($range, -1, 1) == '>':
 
-    	        if (count($fields) === 0) {
+    	        if (\count($fields) === 0) {
     	    	    return false;
     	    	}
 		    
@@ -1260,7 +1260,7 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
     	    }
     	}
 
-    	if (true && (is_array($references) && count($references) === 0)) {
+    	if (true && (\is_array($references) && \count($references) === 0)) {
     	    $backup = true;
     	}
 
@@ -1277,7 +1277,7 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
     	    return $references;
     	}
 
-    	if (is_array($references)) {
+    	if (\is_array($references)) {
     	    foreach ($references as $key => $val) {
     	        $references[$key] = preg_split("/ +/", trim($val), -1, PREG_SPLIT_NO_EMPTY);
     	    }
@@ -1287,11 +1287,11 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
     	switch (true) {
 
     	    // Expect one article
-    	    case is_null($range):
-    	    case is_int($range):
-    	    case is_string($range) && ctype_digit($range):
-    	    case is_string($range) && substr($range, 0, 1) == '<' && substr($range, -1, 1) == '>':
-    	        if (count($references) === 0) {
+    	    case \is_null($range):
+    	    case \is_int($range):
+    	    case \is_string($range) && ctype_digit($range):
+    	    case \is_string($range) && substr($range, 0, 1) == '<' && substr($range, -1, 1) == '>':
+    	        if (\count($references) === 0) {
     	    	    return false;
     	    	}
 		    

--- a/NNTP/Error.php
+++ b/NNTP/Error.php
@@ -108,7 +108,7 @@ class Net_NNTP_Error
      */
     public function __toString(): string
     {
-        $str = get_class($this) . ': ' . $this->message;
+        $str = \get_class($this) . ': ' . $this->message;
         if ($this->code !== null) {
             $str .= ' (code: ' . $this->code . ')';
         }

--- a/NNTP/Protocol/Client.php
+++ b/NNTP/Protocol/Client.php
@@ -76,7 +76,7 @@ require_once __DIR__.'/Responsecode.php';
 /**
  * Log level constant for debug messages (compatible with PEAR_LOG_DEBUG)
  */
-if (!defined('PEAR_LOG_DEBUG')) {
+if (!\defined('PEAR_LOG_DEBUG')) {
     define('PEAR_LOG_DEBUG', 7);
 }
 
@@ -285,7 +285,7 @@ class Net_NNTP_Protocol_Client
     protected function _sendCommand(string $cmd): mixed
     {
         // NNTP/RFC977 only allows command up to 512 (-2) chars.
-        if (strlen($cmd) > 510) {
+        if (\strlen($cmd) > 510) {
             return $this->throwError('Failed writing to socket! (Command to long - max 510 chars)');
         }
 
@@ -416,14 +416,14 @@ class Net_NNTP_Protocol_Client
             $line .= $recieved;
 
             // Continue if the line is not terminated by CRLF
-            if (substr($line, -2) != "\r\n" || strlen($line) < 2) {
+            if (substr($line, -2) != "\r\n" || \strlen($line) < 2) {
                 continue;
             }
 
             // Validate recieved line
             if (false) {
                 // Lines should/may not be longer than 998+2 chars (RFC2822 2.3)
-                if (strlen($line) > 1000) {
+                if (\strlen($line) > 1000) {
     	    	    if ($this->_logger) {
     	    	    	$this->_logger->notice('Max line length...');
     	    	    }
@@ -479,7 +479,7 @@ class Net_NNTP_Protocol_Client
     	/* data should be in the format specified by RFC850 */
 
     	switch (true) {
-    	case is_string($article):
+    	case \is_string($article):
     	    //
     	    @fwrite($this->_socket, preg_replace("|\n\.|", "\n.." , $article));
     	    @fwrite($this->_socket, "\r\n.\r\n");
@@ -493,14 +493,14 @@ class Net_NNTP_Protocol_Client
     	    }
 	    break;
 
-    	case is_array($article):
+    	case \is_array($article):
     	    //
     	    $header = reset($article);
     	    $body = next($article);
 
 /* Experimental...
     	    // If header is an array, implode it.
-    	    if (is_array($header)) {
+    	    if (\is_array($header)) {
     	        $header = implode("\r\n", $header) . "\r\n";
     	    }
 */
@@ -519,7 +519,7 @@ class Net_NNTP_Protocol_Client
 
 /* Experimental...
     	    // If body is an array, implode it.
-    	    if (is_array($body)) {
+    	    if (\is_array($body)) {
     	        $header = implode("\r\n", $body) . "\r\n";
     	    }
 */
@@ -612,14 +612,14 @@ class Net_NNTP_Protocol_Client
     	}
 
     	// v1.0.x API
-    	if (is_int($encryption)) {
+    	if (\is_int($encryption)) {
 	    trigger_error('You are using deprecated API v1.0 in Net_NNTP_Protocol_Client: connect() !', E_USER_NOTICE);
     	    $port = $encryption;
 	    $encryption = false;
     	}
 
     	//
-    	if (is_null($host)) {
+    	if (\is_null($host)) {
     	    $host = 'localhost';
     	}
 
@@ -628,12 +628,12 @@ class Net_NNTP_Protocol_Client
 	    case null:
 	    case false:
 		$transport = 'tcp';
-    	    	$port = is_null($port) ? 119 : $port;
+    	    	$port = \is_null($port) ? 119 : $port;
 		break;
 	    case 'ssl':
 	    case 'tls':
 		$transport = $encryption;
-    	    	$port = is_null($port) ? 563 : $port;
+    	    	$port = \is_null($port) ? 563 : $port;
 	        $this->_encryption = $encryption;
 		break;
 	    default:
@@ -641,7 +641,7 @@ class Net_NNTP_Protocol_Client
     	}
 
     	//
-    	if (is_null($timeout)) {
+    	if (\is_null($timeout)) {
     	    $timeout = 15;
     	}
 
@@ -844,7 +844,7 @@ class Net_NNTP_Protocol_Client
     	    	    	$this->_logger?->info('TLS encryption failed.');
     	    	    	return $this->throwError('Could not initiate TLS negotiation', $response, $this->_currentStatusResponse());
     	    	    	break;
-    	    	    case is_int($encrypted):
+    	    	    case \is_int($encrypted):
     	    	    	return $this->throwError('', $response, $this->_currentStatusResponse());
     	    	    	break;
     	    	    default:
@@ -915,10 +915,10 @@ class Net_NNTP_Protocol_Client
      */
     protected function cmdListgroup(?string $newsgroup = null, mixed $range = null): mixed
     {
-        if (is_null($newsgroup)) {
+        if (\is_null($newsgroup)) {
     	    $command = 'LISTGROUP';
     	} else {
-    	    if (is_null($range)) {
+    	    if (\is_null($range)) {
     	        $command = 'LISTGROUP ' . $newsgroup;
     	    } else {
     	        $command = 'LISTGROUP ' . $newsgroup . ' ' . $range;
@@ -1062,7 +1062,7 @@ class Net_NNTP_Protocol_Client
      */
     protected function cmdArticle(mixed $article = null): mixed
     {
-        if (is_null($article)) {
+        if (\is_null($article)) {
     	    $command = 'ARTICLE';
     	} else {
             $command = 'ARTICLE ' . $article;
@@ -1116,7 +1116,7 @@ class Net_NNTP_Protocol_Client
      */
     protected function cmdHead(mixed $article = null): mixed
     {
-        if (is_null($article)) {
+        if (\is_null($article)) {
     	    $command = 'HEAD';
     	} else {
             $command = 'HEAD ' . $article;
@@ -1169,7 +1169,7 @@ class Net_NNTP_Protocol_Client
      */
     protected function cmdBody(mixed $article = null): mixed
     {
-        if (is_null($article)) {
+        if (\is_null($article)) {
     	    $command = 'BODY';
     	} else {
             $command = 'BODY ' . $article;
@@ -1222,7 +1222,7 @@ class Net_NNTP_Protocol_Client
      */
     protected function cmdStat(mixed $article = null): mixed
     {
-        if (is_null($article)) {
+        if (\is_null($article)) {
     	    $command = 'STAT';
     	} else {
             $command = 'STAT ' . $article;
@@ -1449,7 +1449,7 @@ class Net_NNTP_Protocol_Client
     {
 	$date = gmdate('ymd His', $time);
 
-        if (is_null($distributions)) {
+        if (\is_null($distributions)) {
     	    $command = 'NEWGROUPS ' . $date . ' GMT';
     	} else {
     	    $command = 'NEWGROUPS ' . $date . ' GMT <' . $distributions . '>';
@@ -1500,14 +1500,14 @@ class Net_NNTP_Protocol_Client
     {
         $date = gmdate('ymd His', $time);
 
-    	if (is_array($newsgroups)) {
+    	if (\is_array($newsgroups)) {
     	    $newsgroups = implode(',', $newsgroups);
     	}
 
-        if (is_null($distribution)) {
+        if (\is_null($distribution)) {
     	    $command = 'NEWNEWS ' . $newsgroups . ' ' . $date . ' GMT';
     	} else {
-    	    if (is_array($distribution)) {
+    	    if (\is_array($distribution)) {
     		$distribution = implode(',', $distribution);
     	    }
 
@@ -1588,7 +1588,7 @@ class Net_NNTP_Protocol_Client
      */
     protected function cmdListActive(?string $wildmat = null): mixed
     {
-        if (is_null($wildmat)) {
+        if (\is_null($wildmat)) {
     	    $command = 'LIST ACTIVE';
     	} else {
             $command = 'LIST ACTIVE ' . $wildmat;
@@ -1638,7 +1638,7 @@ class Net_NNTP_Protocol_Client
      */
     protected function cmdListNewsgroups(?string $wildmat = null): mixed
     {
-        if (is_null($wildmat)) {
+        if (\is_null($wildmat)) {
     	    $command = 'LIST NEWSGROUPS';
     	} else {
             $command = 'LIST NEWSGROUPS ' . $wildmat;
@@ -1697,7 +1697,7 @@ class Net_NNTP_Protocol_Client
 	 */
     protected function cmdOver(?string $range = null): mixed
     {
-        if (is_null($range)) {
+        if (\is_null($range)) {
 	    $command = 'OVER';
     	} else {
     	    $command = 'OVER ' . $range;
@@ -1757,11 +1757,11 @@ class Net_NNTP_Protocol_Client
     protected function cmdXOver(?string $range = null): mixed
     {
 	// deprecated API (the code _is_ still in alpha state)
-    	if (func_num_args() > 1 ) {
+    	if (\func_num_args() > 1 ) {
     	    die('The second parameter in cmdXOver() has been deprecated! Use x-y instead...');
         }
 
-        if (is_null($range)) {
+        if (\is_null($range)) {
 	    $command = 'XOVER';
     	} else {
     	    $command = 'XOVER ' . $range;
@@ -1868,7 +1868,7 @@ class Net_NNTP_Protocol_Client
      */
     protected function cmdXHdr(string $field, ?string $range = null): mixed
     {
-        if (is_null($range)) {
+        if (\is_null($range)) {
 	    $command = 'XHDR ' . $field;
     	} else {
     	    $command = 'XHDR ' . $field . ' ' . $range;
@@ -1969,11 +1969,11 @@ class Net_NNTP_Protocol_Client
     protected function cmdXROver(?string $range = null): mixed
     {
 	// Warn about deprecated API (the code _is_ still in alpha state)
-    	if (func_num_args() > 1 ) {
+    	if (\func_num_args() > 1 ) {
     	    die('The second parameter in cmdXROver() has been deprecated! Use x-y instead...');
     	}
 
-        if (is_null($range)) {
+        if (\is_null($range)) {
     	    $command = 'XROVER';
     	} else {
     	    $command = 'XROVER ' . $range;
@@ -2031,7 +2031,7 @@ class Net_NNTP_Protocol_Client
      */
     protected function cmdXPat(string $field, string $range, mixed $wildmat): mixed
     {
-        if (is_array($wildmat)) {
+        if (\is_array($wildmat)) {
 	    $wildmat = implode(' ', $wildmat);
     	}
 
@@ -2168,7 +2168,7 @@ class Net_NNTP_Protocol_Client
      */
     protected function _isConnected(): bool
     {
-        return (is_resource($this->_socket) && (!feof($this->_socket)));
+        return (\is_resource($this->_socket) && (!feof($this->_socket)));
     }
 
     // }}}

--- a/tests/basics.php
+++ b/tests/basics.php
@@ -52,7 +52,7 @@ class Basics
     function test_GetGroups()
     {
 		self::$groups = self::$nntp->getGroups();
-		$this->assertTrue(is_array(self::$groups));
+		$this->assertTrue(\is_array(self::$groups));
     }
 
     /**
@@ -62,7 +62,7 @@ class Basics
     {
 // TODO: Do _not_ set self::$groups
 		self::$nntp->getGroups('php.pear*');
-		$this->assertTrue(is_array(self::$groups));
+		$this->assertTrue(\is_array(self::$groups));
     }
 
     /**
@@ -72,18 +72,18 @@ class Basics
     {
 // TODO: Do _not_ use wildcard here. Create another test with wildcard...
 		$descriptions = self::$nntp->getDescriptions('php.pear*');
-		$this->assertTrue(is_array($descriptions));
+		$this->assertTrue(\is_array($descriptions));
 
 		// Test if at least one description
-		$this->assertTrue(count($descriptions) > 0);
+		$this->assertTrue(\count($descriptions) > 0);
 
 		// Test first description
-		$this->assertTrue(is_string(reset($descriptions)));
-		$this->assertTrue(is_string(key($descriptions)));
+		$this->assertTrue(\is_string(reset($descriptions)));
+		$this->assertTrue(\is_string(key($descriptions)));
 
 		// Test last description
-		$this->assertTrue(is_string(end($descriptions)));
-		$this->assertTrue(is_string(key($descriptions)));
+		$this->assertTrue(\is_string(end($descriptions)));
+		$this->assertTrue(\is_string(key($descriptions)));
 
 		self::$groupDescriptions = $descriptions;
     }
@@ -95,17 +95,17 @@ class Basics
     {
 		// Use the current group in self::$groups
 		self::$group = $summary = self::$nntp->selectGroup( key(self::$groups) );
- 		$this->assertTrue(is_array($summary));
+ 		$this->assertTrue(\is_array($summary));
  
 		$this->assertTrue(isset($summary['group']));
  		$this->assertTrue(isset($summary['first']));
  		$this->assertTrue(isset($summary['last']));
  		$this->assertTrue(isset($summary['count']));
 
-		$this->assertTrue(is_string($summary['group']));
- 		$this->assertTrue(is_string($summary['first']));
- 		$this->assertTrue(is_string($summary['last']));
- 		$this->assertTrue(is_string($summary['count']));
+		$this->assertTrue(\is_string($summary['group']));
+ 		$this->assertTrue(\is_string($summary['first']));
+ 		$this->assertTrue(\is_string($summary['last']));
+ 		$this->assertTrue(\is_string($summary['count']));
  
 		$this->assertTrue(is_numeric($summary['first']));
  		$this->assertTrue(is_numeric($summary['last']));
@@ -120,16 +120,16 @@ class Basics
 		$group = self::$group['group'];
 		
 		$descriptions = self::$nntp->getDescriptions($group);
-		$this->assertTrue(is_array($descriptions));
+		$this->assertTrue(\is_array($descriptions));
 
 		// Test if excatly one description
-		$this->assertTrue(count($descriptions) == 1);
+		$this->assertTrue(\count($descriptions) == 1);
 
 		// Test if group is as expected
 		$this->assertTrue(isset($descriptions[$group]));
 
 		// Test if description is a string
-		$this->assertTrue(is_string($descriptions[$group]));
+		$this->assertTrue(\is_string($descriptions[$group]));
 		
 		self::$groupDescription = $descriptions[$group];
     }
@@ -140,7 +140,7 @@ class Basics
     function test_SelectFirstArticle()
     {
 		self::$article = self::$nntp->selectArticle(self::$nntp->first());
-		$this->assertTrue(is_int(self::$article));
+		$this->assertTrue(\is_int(self::$article));
     }
 	
     /**
@@ -149,10 +149,10 @@ class Basics
     function test_getFirstArticle()
     {
 		$header = self::$nntp->getHeader();
-		$this->assertTrue(is_array($header));
+		$this->assertTrue(\is_array($header));
 
 		$body = self::$nntp->getBody();
-		$this->assertTrue(is_array($body));
+		$this->assertTrue(\is_array($body));
     }
 
     /**
@@ -161,7 +161,7 @@ class Basics
     function test_SelectLastArticle()
     {
 		self::$article = self::$nntp->selectArticle(self::$nntp->last());
-		$this->assertTrue(is_int(self::$article));
+		$this->assertTrue(\is_int(self::$article));
     }
 	
     /**
@@ -170,10 +170,10 @@ class Basics
     function test_getLastArticle()
     {
 		$header = self::$nntp->getHeader();
-		$this->assertTrue(is_array($header));
+		$this->assertTrue(\is_array($header));
 
 		$body = self::$nntp->getBody();
-		$this->assertTrue(is_array($body));
+		$this->assertTrue(\is_array($body));
     }
 
     /**

--- a/tests/benchmark_integration.php
+++ b/tests/benchmark_integration.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+ini_set('memory_limit', '1024M');
+
 require_once __DIR__ . '/../NNTP/Client.php';
 
 /**
@@ -26,11 +28,6 @@ final class NetNntpBenchmarkClient extends Net_NNTP_Client
     public function fetchXoverRaw(string $range): mixed
     {
         return $this->cmdXOver($range);
-    }
-
-    public function fetchOverRaw(string $range): mixed
-    {
-        return $this->cmdOver($range);
     }
 
     public function fetchXoverUsingLegacyReader(string $range): mixed
@@ -159,7 +156,6 @@ function parseOptions(): array
         'range:',
         'iterations::',
         'timeout::',
-        'include-over::',
         'include-legacy-reader::',
         'help::',
     ]);
@@ -174,7 +170,6 @@ function parseOptions(): array
         'range' => $opts['range'] ?? getenv('NNTP_RANGE') ?: null,
         'iterations' => max(1, (int) ($opts['iterations'] ?? getenv('NNTP_ITERATIONS') ?: 3)),
         'timeout' => max(1, (int) ($opts['timeout'] ?? getenv('NNTP_TIMEOUT') ?: 15)),
-        'includeOver' => array_key_exists('include-over', $opts),
         'includeLegacyReader' => array_key_exists('include-legacy-reader', $opts),
         'help' => array_key_exists('help', $opts),
     ];
@@ -191,7 +186,7 @@ Usage:
 Required:
   --host                 NNTP host (or NNTP_HOST env)
   --group                Newsgroup to select (or NNTP_GROUP env)
-  --range                Article range for OVER/XOVER, e.g. 100000-100250 (or NNTP_RANGE env)
+  --range                Article range for XOVER, e.g. 100000-100250 (or NNTP_RANGE env)
 
 Options:
   --port=PORT            NNTP port (default: 119, or NNTP_PORT)
@@ -200,7 +195,6 @@ Options:
   --pass=PASS            Password (or NNTP_PASS)
   --iterations=N         Iterations per benchmark (default: 3, or NNTP_ITERATIONS)
   --timeout=SECONDS      Connect timeout in seconds (default: 15, or NNTP_TIMEOUT)
-  --include-over         Benchmark OVER path in addition to XOVER
   --include-legacy-reader Benchmark XOVER using the legacy text-reader implementation
   --help                 Show this message
 TXT;
@@ -377,14 +371,6 @@ try {
         }
     );
 
-    if ($options['includeOver']) {
-        $results[] = runBenchmark(
-            'OVER raw',
-            $iterations,
-            fn (): mixed => $client->fetchOverRaw($range)
-        );
-    }
-
     if ($options['includeLegacyReader']) {
         $results[] = runBenchmark(
             'XOVER using legacy reader',
@@ -423,4 +409,3 @@ try {
 } finally {
     $client->disconnect();
 }
-

--- a/tests/benchmark_integration.php
+++ b/tests/benchmark_integration.php
@@ -77,7 +77,7 @@ final class NetNntpBenchmarkClient extends Net_NNTP_Client
     {
         $fieldNames = array_keys($format);
         $fieldFlags = array_values($format);
-        $fieldCount = count($fieldNames);
+        $fieldCount = \count($fieldNames);
 
         foreach ($overview as $key => $article) {
             $mappedArticle = array();
@@ -118,7 +118,7 @@ final class NetNntpBenchmarkClient extends Net_NNTP_Client
 
             $line .= $received;
 
-            if (substr($line, -2) != "\r\n" || strlen($line) < 2) {
+            if (substr($line, -2) != "\r\n" || \strlen($line) < 2) {
                 usleep(25000);
                 continue;
             }
@@ -170,8 +170,8 @@ function parseOptions(): array
         'range' => $opts['range'] ?? getenv('NNTP_RANGE') ?: null,
         'iterations' => max(1, (int) ($opts['iterations'] ?? getenv('NNTP_ITERATIONS') ?: 3)),
         'timeout' => max(1, (int) ($opts['timeout'] ?? getenv('NNTP_TIMEOUT') ?: 15)),
-        'includeLegacyReader' => array_key_exists('include-legacy-reader', $opts),
-        'help' => array_key_exists('help', $opts),
+        'includeLegacyReader' => \array_key_exists('include-legacy-reader', $opts),
+        'help' => \array_key_exists('help', $opts),
     ];
 
     return $values;
@@ -208,7 +208,7 @@ TXT;
 function median(array $values): float
 {
     sort($values);
-    $count = count($values);
+    $count = \count($values);
 
     if ($count === 0) {
         return 0.0;
@@ -242,8 +242,8 @@ function runBenchmark(string $name, int $iterations, callable $callback): array
             throw new RuntimeException($name . ' failed: ' . $result->getMessage() . ' [' . $result->getCode() . ']');
         }
 
-        if (is_array($result)) {
-            $rows = count($result);
+        if (\is_array($result)) {
+            $rows = \count($result);
         }
     }
 
@@ -254,7 +254,7 @@ function runBenchmark(string $name, int $iterations, callable $callback): array
         'median_ms' => median($times),
         'min_ms' => min($times),
         'max_ms' => max($times),
-        'avg_ms' => array_sum($times) / count($times),
+        'avg_ms' => array_sum($times) / \count($times),
     ];
 }
 

--- a/tests/benchmark_integration.php
+++ b/tests/benchmark_integration.php
@@ -1,0 +1,426 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../NNTP/Client.php';
+
+/**
+ * End-to-end NNTP benchmark helper.
+ *
+ * Usage example:
+ * php tests/benchmark_integration.php \
+ *   --host=your.news.server \
+ *   --port=563 \
+ *   --encryption=tls \
+ *   --user=your-user \
+ *   --pass=your-pass \
+ *   --group=alt.binaries.example \
+ *   --range=100000-100200 \
+ *   --iterations=5
+ *
+ * Environment fallback:
+ * NNTP_HOST, NNTP_PORT, NNTP_ENCRYPTION, NNTP_USER, NNTP_PASS, NNTP_GROUP, NNTP_RANGE, NNTP_ITERATIONS, NNTP_TIMEOUT
+ */
+final class NetNntpBenchmarkClient extends Net_NNTP_Client
+{
+    public function fetchXoverRaw(string $range): mixed
+    {
+        return $this->cmdXOver($range);
+    }
+
+    public function fetchOverRaw(string $range): mixed
+    {
+        return $this->cmdOver($range);
+    }
+
+    public function fetchXoverUsingLegacyReader(string $range): mixed
+    {
+        $response = $this->_sendCommand('XOVER ' . $range);
+        if (Net_NNTP_Error::isError($response)) {
+            return $response;
+        }
+
+        if ($response !== NET_NNTP_PROTOCOL_RESPONSECODE_OVERVIEW_FOLLOWS) {
+            return $this->_handleUnexpectedResponse($response);
+        }
+
+        $data = $this->getTextResponseLegacy();
+        if (Net_NNTP_Error::isError($data)) {
+            return $data;
+        }
+
+        foreach ($data as $key => $value) {
+            $data[$key] = explode("\t", $value);
+        }
+
+        return $data;
+    }
+
+    public function mapOverviewLegacy(array $overview, array $format): array
+    {
+        foreach ($overview as $key => $article) {
+            $mappedArticle = $format;
+            $index = 0;
+
+            foreach ($mappedArticle as $tag => $full) {
+                $mappedArticle[$tag] = $article[$index++] ?? '';
+
+                if ($full === true) {
+                    $mappedArticle[$tag] = ltrim(substr($mappedArticle[$tag], strpos($mappedArticle[$tag], ':') + 1), " \t");
+                }
+            }
+
+            $overview[$key] = $mappedArticle;
+        }
+
+        return $overview;
+    }
+
+    public function mapOverviewOptimized(array $overview, array $format): array
+    {
+        $fieldNames = array_keys($format);
+        $fieldFlags = array_values($format);
+        $fieldCount = count($fieldNames);
+
+        foreach ($overview as $key => $article) {
+            $mappedArticle = array();
+
+            for ($i = 0; $i < $fieldCount; $i++) {
+                $value = $article[$i] ?? '';
+
+                if ($fieldFlags[$i] === true) {
+                    $position = strpos($value, ':');
+                    $value = ltrim(substr($value, ($position === false ? 0 : $position + 1)), " \t");
+                }
+
+                $mappedArticle[$fieldNames[$i]] = $value;
+            }
+
+            $overview[$key] = $mappedArticle;
+        }
+
+        return $overview;
+    }
+
+    protected function getTextResponseLegacy(): mixed
+    {
+        $data = array();
+        $line = '';
+
+        while (!feof($this->_socket)) {
+            $received = @fgets($this->_socket, 1024);
+
+            if ($received === false) {
+                $meta = stream_get_meta_data($this->_socket);
+                if (!empty($meta['timed_out'])) {
+                    return $this->throwError('Connection timed out', null);
+                }
+
+                return $this->throwError('Failed to read line from socket.', null);
+            }
+
+            $line .= $received;
+
+            if (substr($line, -2) != "\r\n" || strlen($line) < 2) {
+                usleep(25000);
+                continue;
+            }
+
+            $line = substr($line, 0, -2);
+
+            if ($line === '.') {
+                return $data;
+            }
+
+            if (substr($line, 0, 2) == '..') {
+                $line = substr($line, 1);
+            }
+
+            $data[] = $line;
+            $line = '';
+        }
+
+        return $this->throwError('End of stream! Connection lost?', null);
+    }
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function parseOptions(): array
+{
+    $opts = getopt('', [
+        'host:',
+        'port::',
+        'encryption::',
+        'user::',
+        'pass::',
+        'group:',
+        'range:',
+        'iterations::',
+        'timeout::',
+        'include-over::',
+        'include-legacy-reader::',
+        'help::',
+    ]);
+
+    $values = [
+        'host' => $opts['host'] ?? getenv('NNTP_HOST') ?: null,
+        'port' => (int) ($opts['port'] ?? getenv('NNTP_PORT') ?: 119),
+        'encryption' => $opts['encryption'] ?? getenv('NNTP_ENCRYPTION') ?: null,
+        'user' => $opts['user'] ?? getenv('NNTP_USER') ?: null,
+        'pass' => $opts['pass'] ?? getenv('NNTP_PASS') ?: null,
+        'group' => $opts['group'] ?? getenv('NNTP_GROUP') ?: null,
+        'range' => $opts['range'] ?? getenv('NNTP_RANGE') ?: null,
+        'iterations' => max(1, (int) ($opts['iterations'] ?? getenv('NNTP_ITERATIONS') ?: 3)),
+        'timeout' => max(1, (int) ($opts['timeout'] ?? getenv('NNTP_TIMEOUT') ?: 15)),
+        'includeOver' => array_key_exists('include-over', $opts),
+        'includeLegacyReader' => array_key_exists('include-legacy-reader', $opts),
+        'help' => array_key_exists('help', $opts),
+    ];
+
+    return $values;
+}
+
+function printUsage(): void
+{
+    $usage = <<<'TXT'
+Usage:
+  php tests/benchmark_integration.php --host=HOST --group=GROUP --range=RANGE [options]
+
+Required:
+  --host                 NNTP host (or NNTP_HOST env)
+  --group                Newsgroup to select (or NNTP_GROUP env)
+  --range                Article range for OVER/XOVER, e.g. 100000-100250 (or NNTP_RANGE env)
+
+Options:
+  --port=PORT            NNTP port (default: 119, or NNTP_PORT)
+  --encryption=MODE      null|ssl|tls (default: null, or NNTP_ENCRYPTION)
+  --user=USER            Username (or NNTP_USER)
+  --pass=PASS            Password (or NNTP_PASS)
+  --iterations=N         Iterations per benchmark (default: 3, or NNTP_ITERATIONS)
+  --timeout=SECONDS      Connect timeout in seconds (default: 15, or NNTP_TIMEOUT)
+  --include-over         Benchmark OVER path in addition to XOVER
+  --include-legacy-reader Benchmark XOVER using the legacy text-reader implementation
+  --help                 Show this message
+TXT;
+
+    echo $usage . PHP_EOL;
+}
+
+/**
+ * @param array<int, float> $values
+ */
+function median(array $values): float
+{
+    sort($values);
+    $count = count($values);
+
+    if ($count === 0) {
+        return 0.0;
+    }
+
+    $mid = intdiv($count, 2);
+
+    if (($count % 2) === 0) {
+        return ($values[$mid - 1] + $values[$mid]) / 2;
+    }
+
+    return $values[$mid];
+}
+
+/**
+ * @param callable():mixed $callback
+ * @return array<string, mixed>
+ */
+function runBenchmark(string $name, int $iterations, callable $callback): array
+{
+    $times = array();
+    $rows = null;
+
+    for ($i = 0; $i < $iterations; $i++) {
+        $start = hrtime(true);
+        $result = $callback();
+        $elapsedMs = (hrtime(true) - $start) / 1_000_000;
+        $times[] = $elapsedMs;
+
+        if (Net_NNTP_Error::isError($result)) {
+            throw new RuntimeException($name . ' failed: ' . $result->getMessage() . ' [' . $result->getCode() . ']');
+        }
+
+        if (is_array($result)) {
+            $rows = count($result);
+        }
+    }
+
+    return [
+        'benchmark' => $name,
+        'iterations' => $iterations,
+        'rows' => $rows,
+        'median_ms' => median($times),
+        'min_ms' => min($times),
+        'max_ms' => max($times),
+        'avg_ms' => array_sum($times) / count($times),
+    ];
+}
+
+function printResult(array $result): void
+{
+    printf(
+        "%-34s rows=%-7s iter=%-3d median=%9.3fms min=%9.3fms max=%9.3fms avg=%9.3fms\n",
+        (string) $result['benchmark'],
+        (string) ($result['rows'] ?? '-'),
+        (int) $result['iterations'],
+        (float) $result['median_ms'],
+        (float) $result['min_ms'],
+        (float) $result['max_ms'],
+        (float) $result['avg_ms']
+    );
+}
+
+function percentDelta(float $baseline, float $value): float
+{
+    if ($baseline <= 0.0) {
+        return 0.0;
+    }
+
+    return (($value - $baseline) / $baseline) * 100.0;
+}
+
+$options = parseOptions();
+
+if ($options['help']) {
+    printUsage();
+    exit(0);
+}
+
+if (empty($options['host']) || empty($options['group']) || empty($options['range'])) {
+    printUsage();
+    fwrite(STDERR, "Error: --host, --group and --range are required.\n");
+    exit(1);
+}
+
+$client = new NetNntpBenchmarkClient();
+
+try {
+    $connected = $client->connect(
+        (string) $options['host'],
+        $options['encryption'] !== '' ? $options['encryption'] : null,
+        (int) $options['port'],
+        (int) $options['timeout']
+    );
+
+    if (Net_NNTP_Error::isError($connected)) {
+        throw new RuntimeException('Connect failed: ' . $connected->getMessage() . ' [' . $connected->getCode() . ']');
+    }
+
+    if (!empty($options['user'])) {
+        $auth = $client->authenticate((string) $options['user'], (string) ($options['pass'] ?? ''));
+        if (Net_NNTP_Error::isError($auth)) {
+            throw new RuntimeException('Authenticate failed: ' . $auth->getMessage() . ' [' . $auth->getCode() . ']');
+        }
+    }
+
+    $groupSummary = $client->selectGroup((string) $options['group']);
+    if (Net_NNTP_Error::isError($groupSummary)) {
+        throw new RuntimeException('Select group failed: ' . $groupSummary->getMessage() . ' [' . $groupSummary->getCode() . ']');
+    }
+
+    $format = $client->getOverviewFormat(true, true);
+    if (Net_NNTP_Error::isError($format)) {
+        throw new RuntimeException('Failed to fetch overview format: ' . $format->getMessage() . ' [' . $format->getCode() . ']');
+    }
+    $format = array_merge(array('Number' => false), $format);
+
+    echo 'Connected to ' . $options['host'] . ':' . $options['port'] . ' group=' . $options['group'] . ' range=' . $options['range'] . PHP_EOL;
+    echo str_repeat('-', 120) . PHP_EOL;
+
+    $results = array();
+    $iterations = (int) $options['iterations'];
+    $range = (string) $options['range'];
+
+    $results[] = runBenchmark(
+        'getOverview() current',
+        $iterations,
+        fn (): mixed => $client->getOverview($range, true, true)
+    );
+
+    $results[] = runBenchmark(
+        'XOVER raw',
+        $iterations,
+        fn (): mixed => $client->fetchXoverRaw($range)
+    );
+
+    $results[] = runBenchmark(
+        'XOVER + legacy map',
+        $iterations,
+        function () use ($client, $format, $range): mixed {
+            $overview = $client->fetchXoverRaw($range);
+            if (Net_NNTP_Error::isError($overview)) {
+                return $overview;
+            }
+
+            return $client->mapOverviewLegacy($overview, $format);
+        }
+    );
+
+    $results[] = runBenchmark(
+        'XOVER + optimized map',
+        $iterations,
+        function () use ($client, $format, $range): mixed {
+            $overview = $client->fetchXoverRaw($range);
+            if (Net_NNTP_Error::isError($overview)) {
+                return $overview;
+            }
+
+            return $client->mapOverviewOptimized($overview, $format);
+        }
+    );
+
+    if ($options['includeOver']) {
+        $results[] = runBenchmark(
+            'OVER raw',
+            $iterations,
+            fn (): mixed => $client->fetchOverRaw($range)
+        );
+    }
+
+    if ($options['includeLegacyReader']) {
+        $results[] = runBenchmark(
+            'XOVER using legacy reader',
+            $iterations,
+            fn (): mixed => $client->fetchXoverUsingLegacyReader($range)
+        );
+    }
+
+    foreach ($results as $result) {
+        printResult($result);
+    }
+
+    $baseline = null;
+    foreach ($results as $result) {
+        if ($result['benchmark'] === 'getOverview() current') {
+            $baseline = (float) $result['median_ms'];
+            break;
+        }
+    }
+
+    if ($baseline !== null) {
+        echo str_repeat('-', 120) . PHP_EOL;
+        echo "Delta vs getOverview() current (median):" . PHP_EOL;
+        foreach ($results as $result) {
+            $median = (float) $result['median_ms'];
+            printf(
+                "  %-34s %+8.2f%%\n",
+                (string) $result['benchmark'],
+                percentDelta($baseline, $median)
+            );
+        }
+    }
+} catch (Throwable $e) {
+    fwrite(STDERR, 'Benchmark failed: ' . $e->getMessage() . PHP_EOL);
+    exit(1);
+} finally {
+    $client->disconnect();
+}
+


### PR DESCRIPTION
## Summary
This PR improves performance in the most frequently used NNTP read/parse paths and adds a live integration benchmark script focused on `XOVER`.

## Why
`Net_NNTP` is often used in high-volume header retrieval loops where small inefficiencies add up quickly.  
This change targets hot paths while keeping public API behavior the same.

## What Changed
1. `NNTP/Protocol/Client.php`
- Fixed command length validation in `_sendCommand()` (`strlen($cmd) > 510`).
- Replaced regex newline detection with `strpbrk()` in `_sendCommand()`.
- Optimized `_clearOpensslErrors()` by early return + cached debug flag.
- Increased `_getTextResponse()` read buffer from `1024` to `8192`.
- Removed `usleep(25000)` on partial line reads in `_getTextResponse()`.
- Simplified dot-stuffing check.
- Removed unnecessary `trim()` before tab-splitting in `cmdOver()` / `cmdXOver()`.

2. `NNTP/Client.php`
- Optimized `getOverview()` mapping by avoiding per-row format-array cloning and using precomputed field keys/flags.

3. `tests/benchmark_integration.php`
- Added end-to-end benchmark script for real provider testing.
- Benchmarks `getOverview()`, raw `XOVER`, and mapping variants.
- Benchmark is intentionally `XOVER`-only for cross-provider compatibility (many servers reject `OVER`).

4. Call optimized built-ins as `\strlen`, `\is_array`, `\count` etc. for direct opcode compilation across several files.

## Benchmark Preview
Using:
`php benchmark_integration.php --host=xx --group=alt.binaries.boneless --user=xx --pass=xx --range=137480081588-137480085088 --iterations=5 --include-legacy-reader`

- `getOverview() current`: median `1475.920ms`
- `XOVER raw`: median `1369.757ms` (`-7.19%`)
- `XOVER + legacy map`: median `1323.607ms` (`-10.32%`)
- `XOVER + optimized map`: median `1269.196ms` (`-14.01%`)
- `XOVER using legacy reader`: median `1190.952ms` (`-19.31%`)

### Note
Although the benchmark shows a clear improvement. Sometimes over 30%, I cannot notice any difference when running this in production for scanning headers.

## Compatibility
- No public API changes.
- One correctness fix: commands over RFC length limits are now properly rejected.

## Validation
- `php -l NNTP/Protocol/Client.php`
- `php -l NNTP/Client.php`
- `php -l tests/benchmark_integration.php`